### PR TITLE
fail-fast test update

### DIFF
--- a/src/test/java/com/example/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.controller;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -70,15 +71,20 @@ class AuthControllerTest {
         doReturn(new AuthService.AuthResult("token", "userId"))
                 .when(authService).authenticate(username, password);
 
-        mockMvc.perform(post("/login")
+        var action = mockMvc.perform(post("/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                         {
                           "username": "%s",
                           "password": "%s"
                         }
-                        """.formatted(username, password)))
-                .andExpect(expected ? status().isOk() : status().isBadRequest());
+                        """.formatted(username, password)));
+        if (expected) {
+            action.andExpect(status().isOk());
+        } else {
+            action.andExpect(status().isBadRequest())
+                  .andExpect(jsonPath("$.data", hasSize(1)));
+        }
     }
 
     static Stream<Arguments> provideArguments() {
@@ -207,13 +213,15 @@ class AuthControllerTest {
 
         @ParameterizedTest
         @MethodSource("provideInvalidRegistrationArguments")
-        void register_parameterFail(Map<String, ?> diff, String errorCode)
+        void register_parameterFail(Map<String, ?> diff, String field, String errorCode)
                 throws JsonProcessingException, Exception {
             mockMvc.perform(post("/register/complete")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(breakJson(diff)))
                     .andExpect(status().isBadRequest())
-                    .andExpect((jsonPath("$..errorCode", hasItem(errorCode))));
+                    .andExpect(jsonPath("$.data", hasSize(1)))
+                    .andExpect(jsonPath("$.data[0].field").value(field))
+                    .andExpect(jsonPath("$.data[0].errorCode").value(errorCode));
         }
 
         static Stream<Arguments> provideValidRegistrationArguments() {
@@ -278,7 +286,6 @@ class AuthControllerTest {
         }
 
         static Stream<Arguments> provideInvalidRegistrationArguments() {
-            // メール全体 255 文字（= 63 + 1 + 63 + 1 + 63 + 1 + 63）
             String email255 = "a".repeat(63) + "@" +
                     "b".repeat(63) + "." +
                     "c".repeat(63) + "." +
@@ -286,73 +293,74 @@ class AuthControllerTest {
 
             return Stream.of(
                     /* token -------------------------------------------------------------- */
-                    Arguments.of(Map.of("token", ""), "NotBlank"),
-                    Arguments.of(Map.of("token", "a".repeat(21)), "Size"), // <22
-                    Arguments.of(Map.of("token", "a".repeat(23)), "Size"), // >22
+                    Arguments.of(Map.of("token", ""), "token", "NotBlank"),
+                    Arguments.of(Map.of("token", "a".repeat(21)), "token", "Size"),
+                    Arguments.of(Map.of("token", "a".repeat(23)), "token", "Size"),
 
                     /* email -------------------------------------------------------------- */
-                    Arguments.of(Map.of("email", ""), "NotBlank"),
-                    Arguments.of(Map.of("email", email255), "Size"), // >255
+                    Arguments.of(Map.of("email", ""), "email", "NotBlank"),
+                    Arguments.of(Map.of("email", email255), "email", "Size"),
 
                     /* password ----------------------------------------------------------- */
-                    Arguments.of(Map.of("password", ""), "NotBlank"),
-                    Arguments.of(Map.of("password", "1234567"), "Size"), // <8
-                    Arguments.of(Map.of("password", "123456789012345678901"), "Size"), // >20
-                    Arguments.of(Map.of("password", "testあい"), "Pattern"),
+                    Arguments.of(Map.of("password", ""), "password", "NotBlank"),
+                    Arguments.of(Map.of("password", "1234567"), "password", "Size"),
+                    Arguments.of(Map.of("password", "123456789012345678901"), "password", "Size"),
+                    Arguments.of(Map.of("password", "testあい"), "password", "Pattern"),
 
                     /* lastName ----------------------------------------------------------- */
-                    Arguments.of(Map.of("lastName", ""), "NotBlank"),
-                    Arguments.of(Map.of("lastName", "あ".repeat(51)), "Size"),
+                    Arguments.of(Map.of("lastName", ""), "lastName", "NotBlank"),
+                    Arguments.of(Map.of("lastName", "あ".repeat(51)), "lastName", "Size"),
 
                     /* firstName ---------------------------------------------------------- */
-                    Arguments.of(Map.of("firstName", ""), "NotBlank"),
-                    Arguments.of(Map.of("firstName", "あ".repeat(51)), "Size"),
+                    Arguments.of(Map.of("firstName", ""), "firstName", "NotBlank"),
+                    Arguments.of(Map.of("firstName", "あ".repeat(51)), "firstName", "Size"),
 
                     /* lastNameKana ------------------------------------------------------- */
-                    Arguments.of(Map.of("lastNameKana", ""), "NotBlank"),
-                    Arguments.of(Map.of("lastNameKana", "ア".repeat(51)), "Size"),
-                    Arguments.of(Map.of("lastNameKana", "テスト3"), "Pattern"),
+                    Arguments.of(Map.of("lastNameKana", ""), "lastNameKana", "NotBlank"),
+                    Arguments.of(Map.of("lastNameKana", "ア".repeat(51)), "lastNameKana", "Size"),
+                    Arguments.of(Map.of("lastNameKana", "テスト3"), "lastNameKana", "Pattern"),
 
                     /* firstNameKana ------------------------------------------------------ */
-                    Arguments.of(Map.of("firstNameKana", ""), "NotBlank"),
-                    Arguments.of(Map.of("firstNameKana", "ア".repeat(51)), "Size"),
-                    Arguments.of(Map.of("firstNameKana", "テストな"), "Pattern"),
+                    Arguments.of(Map.of("firstNameKana", ""), "firstNameKana", "NotBlank"),
+                    Arguments.of(Map.of("firstNameKana", "ア".repeat(51)), "firstNameKana", "Size"),
+                    Arguments.of(Map.of("firstNameKana", "テストな"), "firstNameKana", "Pattern"),
 
                     /* postCode ----------------------------------------------------------- */
-                    Arguments.of(Map.of("postCode", ""), "NotBlank"),
-                    Arguments.of(Map.of("postCode", "12345678"), "Pattern"), // 8 桁
-                    Arguments.of(Map.of("postCode", "123456a"), "Pattern"), // 英字混入
+                    Arguments.of(Map.of("postCode", ""), "postCode", "NotBlank"),
+                    Arguments.of(Map.of("postCode", "12345678"), "postCode", "Pattern"),
+                    Arguments.of(Map.of("postCode", "123456a"), "postCode", "Pattern"),
 
                     /* addressPrefCity ---------------------------------------------------- */
-                    Arguments.of(Map.of("addressPrefCity", ""), "NotBlank"),
-                    Arguments.of(Map.of("addressPrefCity", "い".repeat(101)), "Size"),
+                    Arguments.of(Map.of("addressPrefCity", ""), "addressPrefCity", "NotBlank"),
+                    Arguments.of(Map.of("addressPrefCity", "い".repeat(101)), "addressPrefCity", "Size"),
 
                     /* addressArea -------------------------------------------------------- */
-                    Arguments.of(Map.of("addressArea", ""), "NotBlank"),
-                    Arguments.of(Map.of("addressArea", "い".repeat(101)), "Size"),
+                    Arguments.of(Map.of("addressArea", ""), "addressArea", "NotBlank"),
+                    Arguments.of(Map.of("addressArea", "い".repeat(101)), "addressArea", "Size"),
 
                     /* addressBuilding (任意) -------------------------------------------- */
-                    Arguments.of(Map.of("addressBuilding", ""), "Size"),
-                    Arguments.of(Map.of("addressBuilding", "い".repeat(101)), "Size"),
+                    Arguments.of(Map.of("addressBuilding", ""), "addressBuilding", "Size"),
+                    Arguments.of(Map.of("addressBuilding", "い".repeat(101)), "addressBuilding", "Size"),
 
                     /* phoneNumber -------------------------------------------------------- */
-                    Arguments.of(Map.of("phoneNumber", ""), "NotBlank"),
-                    Arguments.of(Map.of("phoneNumber", "09012A4567"), "Pattern"), // 非数字
-                    Arguments.of(Map.of("phoneNumber", "0123456789"), "Size"), // 10 桁
-                    Arguments.of(Map.of("phoneNumber", "012345678901"), "Size"), // 12 桁
+                    Arguments.of(Map.of("phoneNumber", ""), "phoneNumber", "NotBlank"),
+                    Arguments.of(Map.of("phoneNumber", "09012A4567"), "phoneNumber", "Pattern"),
+                    Arguments.of(Map.of("phoneNumber", "0123456789"), "phoneNumber", "Size"),
+                    Arguments.of(Map.of("phoneNumber", "012345678901"), "phoneNumber", "Size"),
 
                     /* birthday ----------------------------------------------------------- */
                     Arguments.of(new HashMap<>() {
                         {
                             put("birthday", null);
                         }
-                    }, "NotNull"),
-                    Arguments.of(Map.of("birthday", LocalDate.now().plusYears(3)), "Past"),
+                    }, "birthday", "NotNull"),
+                    Arguments.of(Map.of("birthday", LocalDate.now().plusYears(3)), "birthday", "Past"),
 
                     /* gender ------------------------------------------------------------- */
-                    Arguments.of(Map.of("gender", ""), "NotBlank"),
-                    Arguments.of(Map.of("gender", "U"), "Pattern"),
-                    Arguments.of(Map.of("gender", "MM"), "Pattern"));
+                    Arguments.of(Map.of("gender", ""), "gender", "NotBlank"),
+                    Arguments.of(Map.of("gender", "U"), "gender", "Pattern"),
+                    Arguments.of(Map.of("gender", "MM"), "gender", "Pattern")
+            );
         }
 
         private RegisterUserRequest createValid() {
@@ -396,9 +404,9 @@ class AuthControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$..field", hasItem(expField)))
-                .andExpect(jsonPath(String.format("$..[?(@.field == '%s')].errorCode", expField),
-                        hasItem(expCode)));
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].field").value(expField))
+                .andExpect(jsonPath("$.data[0].errorCode").value(expCode));
     }
 
     static Stream<Arguments> provideInvalidPasswordResetArguments() {
@@ -452,7 +460,12 @@ class AuthControllerTest {
         "'12345678901234567890123', false",
     })
     void completeEmailChange_parameter(String token, boolean expected) throws Exception {
-        mockMvc.perform(get("/profile/email-change/complete").param("token", token))
-        .andExpect(expected ? status().isOk() : status().isBadRequest());
+        var action = mockMvc.perform(get("/profile/email-change/complete").param("token", token));
+        if (expected) {
+            action.andExpect(status().isOk());
+        } else {
+            action.andExpect(status().isBadRequest())
+                  .andExpect(jsonPath("$.data", hasSize(1)));
+        }
     }
 }

--- a/src/test/java/com/example/controller/InquiryControllerTest.java
+++ b/src/test/java/com/example/controller/InquiryControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.controller;
 
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -91,11 +92,12 @@ class InquiryControllerTest {
         Map<String, Object> m = base();
         override.accept(m);
         String json = objectMapper.writeValueAsString(m);
-        
+
         mockMvc.perform(post("/inquiry")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.data", hasSize(1)));
     }
 
     static Stream<Arguments> provideInvalidArguments() {

--- a/src/test/java/com/example/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/controller/ReviewControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.controller;
 
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -39,7 +40,7 @@ class ReviewControllerTest {
         @ParameterizedTest
         @MethodSource("provideArguments")
         void postReview_parameter(Integer rating, String title, String reviewText, boolean expected) throws Exception {
-            mockMvc.perform(post("/review/{productId}", productId)
+            var action = mockMvc.perform(post("/review/{productId}", productId)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""
                             {
@@ -47,8 +48,13 @@ class ReviewControllerTest {
                               "title": "%s",
                               "reviewText": "%s"
                             }
-                            """.formatted(rating, title, reviewText)))
-                    .andExpect(expected ? status().isOk() : status().isBadRequest());
+                            """.formatted(rating, title, reviewText)));
+            if (expected) {
+                action.andExpect(status().isOk());
+            } else {
+                action.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.data", hasSize(1)));
+            }
         }
 
         static Stream<Arguments> provideArguments() {


### PR DESCRIPTION
## Summary
- align validation tests with fail-fast behavior by asserting only one error is returned
- update controller tests to check expected field and code for invalid requests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_689eca061990832faa2a5c0c99dbbfce